### PR TITLE
Add experimental C API

### DIFF
--- a/cmdapp/README.md
+++ b/cmdapp/README.md
@@ -94,3 +94,14 @@ Since `0.6`, [`vtracer`](https://pypi.org/project/vtracer/) is also packaged as 
 ```sh
 pip install vtracer
 ```
+
+## C API (experimental)
+
+For integration with C or C++ projects, the library exposes a simple C interface:
+
+```c
+int vtracer_convert_image_to_svg(const char *input_path, const char *output_path);
+```
+
+The function converts an image to an SVG using the default configuration. It returns
+`0` on success and a non-zero value on failure.

--- a/cmdapp/src/capi.rs
+++ b/cmdapp/src/capi.rs
@@ -1,0 +1,30 @@
+use crate::*;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::path::Path;
+
+/// Convert an image file to an SVG using default configuration.
+/// Returns 0 on success and 1 on failure.
+#[no_mangle]
+pub extern "C" fn vtracer_convert_image_to_svg(
+    input_path: *const c_char,
+    output_path: *const c_char,
+) -> i32 {
+    if input_path.is_null() || output_path.is_null() {
+        return 1;
+    }
+    let input_cstr = unsafe { CStr::from_ptr(input_path) };
+    let output_cstr = unsafe { CStr::from_ptr(output_path) };
+    let input = match input_cstr.to_str() {
+        Ok(s) => Path::new(s),
+        Err(_) => return 1,
+    };
+    let output = match output_cstr.to_str() {
+        Ok(s) => Path::new(s),
+        Err(_) => return 1,
+    };
+    match convert_image_to_svg(input, output, Config::default()) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}

--- a/cmdapp/src/lib.rs
+++ b/cmdapp/src/lib.rs
@@ -10,12 +10,14 @@
 
 mod config;
 mod converter;
+mod capi;
 #[cfg(feature = "python-binding")]
 mod python;
 mod svg;
 
 pub use config::*;
 pub use converter::*;
+pub use capi::*;
 #[cfg(feature = "python-binding")]
 pub use python::*;
 pub use svg::*;


### PR DESCRIPTION
## Summary
- provide an `extern "C"` interface in `capi.rs`
- export the C API from the library
- document the new function in the crate README

## Testing
- `cargo check --manifest-path cmdapp/Cargo.toml`
- `cargo build --manifest-path cmdapp/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_685a6ef3cecc8320b7cea5a15bcfaf44