### PR TITLE
Add basic C API interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Since `0.6`, [`vtracer`](https://pypi.org/project/vtracer/) is also packaged as 
 pip install vtracer
 ```
 
+### C API
+
+A minimal C header is provided in `capi/vtracer.h` for integrating VTracer
+into other languages. The C interface currently exposes a single helper
+function to convert an image file to an SVG using the library's default
+configuration.
+
 ## In the wild
 
 VTracer is used by the following products (open a PR to add yours):

--- a/capi/vtracer.h
+++ b/capi/vtracer.h
@@ -1,0 +1,22 @@
+#ifndef VTRACER_H
+#define VTRACER_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/**
+ * Convert an image file to an SVG using VTracer's default configuration.
+ *
+ * @param input_path  Path to the input raster image.
+ * @param output_path Path where the SVG will be written.
+ * @return true on success, false on failure.
+ */
+bool vtracer_convert_image_to_svg_default(const char *input_path,
+                                          const char *output_path);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* VTRACER_H */

--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -19,6 +19,7 @@ pyo3 = { version = "0.19.0", optional = true }
 
 [features]
 python-binding = ["pyo3"]
+capi = []
 
 [lib]
 name = "vtracer"

--- a/cmdapp/src/capi.rs
+++ b/cmdapp/src/capi.rs
@@ -1,0 +1,32 @@
+use crate::*;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::path::Path;
+
+/// Convert an image file to an SVG using default settings.
+///
+/// Returns `true` on success, `false` otherwise.
+#[no_mangle]
+pub extern "C" fn vtracer_convert_image_to_svg_default(
+    input_path: *const c_char,
+    output_path: *const c_char,
+) -> bool {
+    if input_path.is_null() || output_path.is_null() {
+        return false;
+    }
+    let input = unsafe { CStr::from_ptr(input_path) };
+    let output = unsafe { CStr::from_ptr(output_path) };
+    let input = match input.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let output = match output.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let config = Config::default();
+    match convert_image_to_svg(Path::new(input), Path::new(output), config) {
+        Ok(()) => true,
+        Err(_) => false,
+    }
+}

--- a/cmdapp/src/lib.rs
+++ b/cmdapp/src/lib.rs
@@ -12,11 +12,15 @@ mod config;
 mod converter;
 #[cfg(feature = "python-binding")]
 mod python;
+#[cfg(feature = "capi")]
+mod capi;
 mod svg;
 
 pub use config::*;
 pub use converter::*;
 #[cfg(feature = "python-binding")]
 pub use python::*;
+#[cfg(feature = "capi")]
+pub use capi::*;
 pub use svg::*;
 pub use visioncortex::ColorImage;


### PR DESCRIPTION
## Summary
- add stub C API as capi feature
- expose new API in library
- document usage in README

## Testing
- `cargo test --quiet --manifest-path cmdapp/Cargo.toml --features capi`
- `cargo build --quiet --manifest-path cmdapp/Cargo.toml --features capi`

------
https://chatgpt.com/codex/tasks/task_e_685a6f009690832096dd6d3614f5eb89